### PR TITLE
Add support for CDATA

### DIFF
--- a/protean/detail/xml_writer_impl.hpp
+++ b/protean/detail/xml_writer_impl.hpp
@@ -27,6 +27,7 @@ namespace protean { namespace detail {
         void write_instruction(const variant& instruction);
         void write_element(const variant& element);
         void write_comment(const variant& comment);
+        void write_cdata(const variant& cdata);
         void write_text(const variant& text);
         void write_variant(const variant& value);
 

--- a/protean/xml_common.hpp
+++ b/protean/xml_common.hpp
@@ -40,6 +40,7 @@ namespace protean {
     extern PROTEAN_DECL const char* xml_default_element;
 
     extern PROTEAN_DECL const char* xml_text;
+    extern PROTEAN_DECL const char* xml_cdata;
     extern PROTEAN_DECL const char* xml_comment;
     extern PROTEAN_DECL const char* xml_instruction;
     extern PROTEAN_DECL const char* xml_attributes;

--- a/src/xml_common.cpp
+++ b/src/xml_common.cpp
@@ -10,6 +10,7 @@ namespace protean {
     const char* xml_default_element  = "Variant";
 
     const char* xml_text             = "__text__";
+    const char* xml_cdata            = "__cdata__";
     const char* xml_comment          = "__comment__";
     const char* xml_instruction      = "__instruction__";
     const char* xml_attributes       = "__attributes__";

--- a/src/xml_writer_impl.cpp
+++ b/src/xml_writer_impl.cpp
@@ -143,6 +143,10 @@ namespace protean { namespace detail {
                         {
                             boost::throw_exception(variant_error("Encountered text in document node"));
                         }
+                        else if (it.key()==xml_cdata)
+                        {
+                            boost::throw_exception(variant_error("Encountered CDATA in document node"));
+                        }
                         else if (it.key()==xml_attributes)
                         {
                             boost::throw_exception(variant_error("Encountered attributes in document node"));
@@ -222,6 +226,11 @@ namespace protean { namespace detail {
     void xml_writer_impl::write_comment(const variant& comment)
     {
         m_os << "<!--" << comment.as<std::string>() << "-->";
+    }
+
+	void xml_writer_impl::write_cdata(const variant& cdata)
+    {
+        m_os << "<![CDATA[" << cdata.as<std::string>() << "]]>";
     }
 
     void xml_writer_impl::write_text(const variant& text)
@@ -345,6 +354,11 @@ namespace protean { namespace detail {
                         else if (it.key()==xml_text)
                         {
                             write_text(it.value());
+                            prev_is_text = true;
+                        }
+                        else if (it.key()==xml_cdata)
+                        {
+                            write_cdata(it.value());
                             prev_is_text = true;
                         }
                         else if (it.key()==xml_instruction)

--- a/test/core/test_xml_streams.cpp
+++ b/test/core/test_xml_streams.cpp
@@ -665,4 +665,25 @@ BOOST_AUTO_TEST_CASE(test_xml_float)
     BOOST_CHECK_EQUAL(iss.str(), oss.str());
 }
 
+BOOST_AUTO_TEST_CASE(test_xml_cdata)
+{
+	variant root1(variant::Bag);
+	variant body(variant::Bag);
+	variant inner(variant::Bag);
+	variant cdata("some cdata");
+	inner.insert(xml_cdata, cdata);
+	body.insert("inner", inner);
+	root1.insert("body", body);
+
+    std::stringstream ss;
+    xml_writer writer(ss);
+    writer << root1;
+
+    variant root2;
+    xml_reader reader(ss);
+    reader >> root2;
+
+    BOOST_CHECK(root1.compare(root2)==0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add another XML key (`xml_cdata`), which indicates to the XML writer to write the variant within CDATA brackets.
