### PR TITLE
Fixed XML header emission

### DIFF
--- a/bindings/cs/Protean-cs/Protean.Net.Tests/TestXmlStreams.cs
+++ b/bindings/cs/Protean-cs/Protean.Net.Tests/TestXmlStreams.cs
@@ -201,6 +201,22 @@ namespace Protean.Test
             Assert.IsTrue(v1.Equals(v2));
         }
 
+        [Test]
+        public void TestHeaderOutput()
+        {
+            Variant value = new Variant(Variant.EnumType.Bag);
+            value.Add("key1", new Variant("value1"));
+            value.Add("key2", new Variant(1.0));
+
+            var expectUtf8Header = XmlWriter.ToString(value);
+
+            Assert.That(expectUtf8Header, Is.EqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Variant variant=\"Bag\"><key1 variant=\"String\">value1</key1><key2 variant=\"Double\">1</key2></Variant>"));
+
+            var expectNoHeader = XmlWriter.ToString(value, XmlMode.NoHeader);
+
+            Assert.That(expectNoHeader, Is.EqualTo("<Variant variant=\"Bag\"><key1 variant=\"String\">value1</key1><key2 variant=\"Double\">1</key2></Variant>"));
+        }
+
 #if !DISABLE_DATATABLE
         [Test]
         public void TestDataTable()

--- a/bindings/cs/Protean-cs/Protean.Net/BinaryWriter.cs
+++ b/bindings/cs/Protean-cs/Protean.Net/BinaryWriter.cs
@@ -19,8 +19,7 @@ namespace Protean
 			m_stream = stream;
 			if ((m_mode & BinaryMode.Compress) != 0)
 			{
-                DeflateStream ds = new DeflateStream(stream, CompressionMode.Compress, true);
-                m_filter = new BufferedStream(ds, c_bufferSize);
+			    m_filter = new DeflateStream(stream, CompressionMode.Compress, true);
 			}
 			else
 			{

--- a/bindings/cs/Protean-cs/Protean.Net/VariantPrimitive.cs
+++ b/bindings/cs/Protean-cs/Protean.Net/VariantPrimitive.cs
@@ -42,49 +42,62 @@ namespace Protean {
 
         public static string ToString<T>(T value)
         {
-            if (typeof(T) == typeof(TimeSpan))
+            var type = typeof(T);
+
+            if (type == typeof(TimeSpan))
             {
-                return VariantBase.ToString((TimeSpan)Convert.ChangeType(value, typeof(TimeSpan)));
+                return VariantBase.ToString((TimeSpan)Convert.ChangeType(value, type));
             }
             else
             {
-                TypeCode typeCode = System.Type.GetTypeCode(typeof(T));
-                switch (typeCode)
+                if (type == typeof(double))
                 {
-                    case TypeCode.Double:
-                        return VariantBase.ToString((double)Convert.ChangeType(value, typeof(double)));
-                    case TypeCode.Boolean:
-                        return VariantBase.ToString((bool)Convert.ChangeType(value, typeof(bool)));
-                    case TypeCode.DateTime:
-                        return VariantBase.ToString((DateTime)Convert.ChangeType(value, typeof(DateTime)));
-                    default:
-                        return value.ToString();
+                    return VariantBase.ToString((double)Convert.ChangeType(value, type));
+                }
+                else if (type == typeof(bool))
+                {
+                    return VariantBase.ToString((bool)Convert.ChangeType(value, type));
+                }
+                else if (type == typeof(DateTime))
+                {
+                    return VariantBase.ToString((DateTime)Convert.ChangeType(value, type));
+                }
+                else
+                {
+                    return value.ToString();
                 }
             }
         }
 
         public static T Parse<T>(string value)
         {
-            if (typeof(T) == typeof(TimeSpan))
+            var type = typeof(T);
+
+            if (type == typeof(TimeSpan))
             {
-                return (T)Convert.ChangeType(VariantBase.ParseTime(value), typeof(T));
+                return (T)Convert.ChangeType(VariantBase.ParseTime(value), type);
             }
             else
             {
-
-                TypeCode typeCode = System.Type.GetTypeCode(typeof(T));
-                switch (typeCode)
+                if (type == typeof(float))
                 {
-                    case TypeCode.Single:
-                        return (T)Convert.ChangeType(VariantBase.ParseSingle(value), typeof(T));
-                    case TypeCode.Double:
-                        return (T)Convert.ChangeType(VariantBase.ParseDouble(value), typeof(T));
-                    case TypeCode.Boolean:
-                        return (T)Convert.ChangeType(VariantBase.ParseBoolean(value), typeof(T));
-                    case TypeCode.DateTime:
-                        return (T)Convert.ChangeType(VariantBase.ParseDateTime(value), typeof(T));
-                    default:
-                        return (T)Convert.ChangeType(value, typeof(T));
+                    return (T)Convert.ChangeType(VariantBase.ParseSingle(value), type);
+                }
+                else if (type == typeof(double))
+                {
+                    return (T)Convert.ChangeType(VariantBase.ParseDouble(value), type);
+                }
+                else if (type == typeof(bool))
+                {
+                    return (T)Convert.ChangeType(VariantBase.ParseBoolean(value), type);
+                }
+                else if (type == typeof(DateTime))
+                {
+                    return (T)Convert.ChangeType(VariantBase.ParseDateTime(value), type);
+                }
+                else
+                {
+                    return (T)Convert.ChangeType(value, type);
                 }
             }
         }

--- a/bindings/cs/Protean-cs/Protean.Net/XmlWriter.cs
+++ b/bindings/cs/Protean-cs/Protean.Net/XmlWriter.cs
@@ -20,6 +20,7 @@ namespace Protean {
             var xmlWriterSettings = new XmlWriterSettings
                                     {
                                         Indent = mode.HasFlag(XmlMode.Indent),
+                                        OmitXmlDeclaration = mode.HasFlag(XmlMode.NoHeader),
                                         IndentChars = "  "
                                     };
             m_writer = System.Xml.XmlWriter.Create(stream, xmlWriterSettings);
@@ -85,12 +86,12 @@ namespace Protean {
             m_stack.Pop();
         }
 
-        void WriteHeader()
+        private void WriteHeader()
         {
             m_writer.WriteProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
         }
 
-        void WriteDocument(Variant document)
+        private void WriteDocument(Variant document)
         {
             if ((m_mode & XmlMode.NoHeader) == 0)
             {
@@ -149,7 +150,7 @@ namespace Protean {
             }
         }
 
-        void WriteInstruction(Variant instruction)
+        private void WriteInstruction(Variant instruction)
         {
             if (instruction.Is(VariantBase.EnumType.Mapping) && instruction.ContainsKey(XmlConst.Target) && instruction.ContainsKey(XmlConst.Data))
             {
@@ -161,7 +162,7 @@ namespace Protean {
             }
         }
 
-        void WriteAttributes(Variant attribute)
+        private void WriteAttributes(Variant attribute)
         {
             foreach (VariantItem item in attribute)
             {
@@ -169,7 +170,7 @@ namespace Protean {
             }
         }
 
-        void WriteStartTag(string name)
+        private void WriteStartTag(string name)
         {
             if (m_stack.Count!=0)
             {
@@ -178,17 +179,17 @@ namespace Protean {
              }
         }
 
-        void WriteEndTag()
+        private void WriteEndTag()
         {
             m_writer.WriteEndElement();
         }
 
-        void WriteComment(Variant comment)
+        private void WriteComment(Variant comment)
         {
             m_writer.WriteComment(comment.As<string>());
         }
 
-        void WriteText(Variant text)
+        private void WriteText(Variant text)
         {
             switch(text.Type)
             {
@@ -217,7 +218,7 @@ namespace Protean {
             }
         }
 
-        void WriteVariant(Variant value)
+        private void WriteVariant(Variant value)
         {
             if ((m_mode & XmlMode.Preserve)==0)
             {
@@ -227,7 +228,7 @@ namespace Protean {
             WriteElement(value);
         }
 
-        void WriteElement(Variant element)
+        private void WriteElement(Variant element)
         {
             WriteStartTag(m_stack.Peek().m_name);
             
@@ -534,7 +535,7 @@ namespace Protean {
             WriteEndTag();
         }
 
-        delegate void WriteDelegate(object arg);
+        private delegate void WriteDelegate(object arg);
 
         private readonly System.Xml.XmlWriter m_writer;
         private readonly XmlMode m_mode;

--- a/bindings/cs/Protean-cs/Protean.Net/project.json
+++ b/bindings/cs/Protean-cs/Protean.Net/project.json
@@ -1,6 +1,6 @@
 {
   "title": "Protean.Net",
-  "version": "2.0.2-*",
+  "version": "2.0.3-*",
   "authors": [ "Johan Ditmar", "Karel Hruda", "Paul O'Neill" ],
   "copyright": "Copyright � Johan Ditmar, Karel Hruda, Paul O'Neill and Luke Stedman",
   "buildOptions": {
@@ -21,7 +21,7 @@
   },
 
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.1",
         "System.Data.Common": "4.1.0",


### PR DESCRIPTION
The `XmlMode.NoHeader` flag was being ignored. This PR fixes that.

This PR also reduces the .NET Standard target from 1.6 to 1.3. This needed a couple of small code changes which could probably be classed as premature optimisation.