### PR TITLE
Build updates for Mac and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ projects/packages
 *.o
 *.os
 .sconsign.dblite
-libprotean.so
+*.so
+*.dylib
 protean_test

--- a/SConstruct
+++ b/SConstruct
@@ -39,7 +39,7 @@ protean_test = \
                 source     = Glob('test/core/*.cpp'),
                 CPPDEFINES = ['BOOST_TEST_DYN_LINK'],
                 LIBS       = libs+[protean, 'boost_unit_test_framework'],
-                RPATH      = '.')
+                LINKFLAGS  = ['-Wl,-rpath', '.', '-Wl,-rpath', '/usr/local/lib'])
 
 def copy_libs(target, source, env):
     if sys.platform != 'linux2':

--- a/SConstruct
+++ b/SConstruct
@@ -9,14 +9,14 @@ libs = ['libboost_date_time',
              'libboost_filesystem',
              'libboost_iostreams',
              'libboost_regex',
-             'libboost_system',
-             'libxerces-c-3.1']
+             'libboost_system']
 
 include_paths, lib_paths, linkflags = [], [], []
 if sys.platform == 'linux2':
+    libs += ['libxerces-c-3.1']
     linkflags = ['-Wl,--gc-sections', '-Wl,-rpath', '.']
 if sys.platform == 'darwin':
-    libs = [ File('/usr/local/lib/'+lib+'.a') for lib in libs ] + ['z', 'curl']
+    libs = [ File('/usr/local/lib/'+lib+'.a') for lib in libs ] + ['libxerces-c'] + ['z', 'curl']
     include_paths = ['/usr/local/include']
     lib_paths = ['/usr/local/lib']
     linkflags = ['-Wl,-dead_strip', '-v', '-install_name', '@loader_path/libprotean.dylib', '-dynamiclib']

--- a/SConstruct
+++ b/SConstruct
@@ -11,21 +11,19 @@ libs = ['libboost_date_time',
              'libboost_regex',
              'libboost_system']
 
-include_paths, lib_paths, linkflags = [], [], []
+linkflags = []
 if sys.platform == 'linux2':
     libs += ['libxerces-c-3.1']
     linkflags = ['-Wl,--gc-sections', '-Wl,-rpath', '.']
 if sys.platform == 'darwin':
     libs = [ File('/usr/local/lib/'+lib+'.a') for lib in libs ] + ['libxerces-c'] + ['z', 'curl']
-    include_paths = ['/usr/local/include']
-    lib_paths = ['/usr/local/lib']
     linkflags = ['-Wl,-dead_strip', '-v', '-install_name', '@loader_path/libprotean.dylib', '-dynamiclib']
 
-env = Environment(CPPPATH=['#'] + include_paths,
+env = Environment(CPPPATH=['#'],
                   CPPFLAGS=['-Wno-multichar', '-std=c++11',
                     '-O3', '-fdata-sections', '-ffunction-sections'],
                   LINKFLAGS=linkflags,
-                  LIBPATH=['#'] + lib_paths)
+                  LIBPATH=['#'])
 
 
 env['CXX'] = os.getenv('CXX') or env['CXX']

--- a/protean/detail/data_table_column.ipp
+++ b/protean/detail/data_table_column.ipp
@@ -96,7 +96,7 @@ namespace protean { namespace detail {
         { push_back_impl_tmpl<type>(value, p); }
 
     template <variant_base::enum_type_t E>
-    void data_table_column<E>::push_back_impl(const variant& value, variant* p = 0)
+    void data_table_column<E>::push_back_impl(const variant& value, variant* p/* = 0*/)
     { push_back_variant_impl_tmpl<variant>(value, p); }
 
 #if defined(_MSC_VER)

--- a/protean/variant.ipp
+++ b/protean/variant.ipp
@@ -230,7 +230,7 @@ namespace protean {
         }
         else
         {
-            boost::throw_exception(variant_error(std::string("Attempt to coerce ") + typeid(*obj).name() + " into object of type " + typeid(T).name()));
+            boost::throw_exception(variant_error(std::string("Attempt to coerce ") + typeid(object).name() + " into object of type " + typeid(T).name()));
         }
 
         END_TRANSLATE_ERROR();

--- a/src/data_table.cpp
+++ b/src/data_table.cpp
@@ -129,7 +129,7 @@ namespace protean { namespace detail {
 
         // If this data table has less rows than the RHS data table, return -1; if more, return 1
         if (size() != cast_rhs->size())
-            return rhs.size() - cast_rhs->size() < 0 ? -1 : 1;
+            return size() < cast_rhs->size() ? -1 : 1;
 
         // Else the data tables have the same number of rows, so compare each row (tuple)
         variant_iterator<const_iterator_traits> this_iter = begin(),


### PR DESCRIPTION
scons now builds a mac build (with statically linked xerces and boost) and a Linux build with shared libs for xerces and boost. 

I'd like to keep these consistent and preferably statically linked but the boost RPM in RHEL that I'm using appears to not compile the boost static libs as PIC. 