### PR TITLE
Added extra options to SConstruct (controlled via env var)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ On other platforms:
 
 - Install `boost`, `xerces` and `scons` dependencies, e.g. via `yum` or `apt-get`.
 - Build via `scons`.
+- If you wish to provide alternate include or lib paths, set `CPPPATH` or `LIBPATH` env vars respectively. You can also override the Boost version, via `BOOST_VERSION`.
 
 ## Usage examples ##
 

--- a/SConstruct
+++ b/SConstruct
@@ -3,57 +3,59 @@ import shutil
 import subprocess
 import sys
 
-linux_boost_version = '1.54.0'
+linux_boost_version = os.getenv('BOOST_VERSION', '1.54.0')
 
 libs = ['libboost_date_time',
-             'libboost_filesystem',
-             'libboost_iostreams',
-             'libboost_regex',
-             'libboost_system']
+        'libboost_filesystem',
+        'libboost_iostreams',
+        'libboost_regex',
+        'libboost_system']
 
-linkflags = []
+link_flags = []
 if sys.platform == 'linux2':
     libs += ['libxerces-c-3.1']
-    linkflags = ['-Wl,--gc-sections', '-Wl,-rpath', '.']
+    link_flags = ['-Wl,--gc-sections', '-Wl,-rpath', '.']
 if sys.platform == 'darwin':
     libs = [ File('/usr/local/lib/'+lib+'.a') for lib in libs ] + ['libxerces-c'] + ['z', 'curl']
-    linkflags = ['-Wl,-dead_strip', '-v', '-install_name', '@loader_path/libprotean.dylib', '-dynamiclib']
+    link_flags = ['-Wl,-dead_strip', '-v', '-install_name', '@loader_path/libprotean.dylib', '-dynamiclib']
 
-env = Environment(CPPPATH=['#'],
-                  CPPFLAGS=['-Wno-multichar', '-std=c++11',
-                    '-O3', '-fdata-sections', '-ffunction-sections'],
-                  LINKFLAGS=linkflags,
-                  LIBPATH=['#'])
+cpp_path = os.getenv('CPPPATH', '').split(os.pathsep) + ["#"]
+lib_path = os.getenv('LIBPATH', '').split(os.pathsep) + ["#"]
 
+env = Environment(ENV       = {'PATH': os.getenv('PATH')},
+                  CPPPATH   = cpp_path,
+                  CPPFLAGS  = ['-Wno-multichar', '-std=c++11',
+                               '-O3', '-fdata-sections', '-ffunction-sections'],
+                  LINKFLAGS = link_flags,
+                  LIBPATH   = lib_path)
 
 env['CXX'] = os.getenv('CXX') or env['CXX']
 env['PREFIX'] = os.getenv('PREFIX') or '/usr'
 
-protean = env.SharedLibrary(target = 'protean',
-                            source = Glob('src/*.cpp'),
-                            LIBS=libs,
-                            FRAMEWORKS=['CoreServices'])
+protean = env.SharedLibrary(target     = 'protean',
+                            source     = Glob('src/*.cpp'),
+                            LIBS       = libs,
+                            FRAMEWORKS = ['CoreServices'])
 
-protean_test = \
-    env.Program(target     = 'protean_test',
-                source     = Glob('test/core/*.cpp'),
-                CPPDEFINES = ['BOOST_TEST_DYN_LINK'],
-                LIBS       = libs+[protean, 'boost_unit_test_framework'],
-                LINKFLAGS  = ['-Wl,-rpath', '.', '-Wl,-rpath', '/usr/local/lib'])
+if int(os.getenv('BUILD_TESTS', 1)):
+    protean_test = \
+        env.Program(target     = 'protean_test',
+                    source     = Glob('test/core/*.cpp'),
+                    CPPDEFINES = ['BOOST_TEST_DYN_LINK'],
+                    LIBS       = libs+[protean, 'boost_unit_test_framework'],
+                    LINKFLAGS  = ['-Wl,-rpath', '.', '-Wl,-rpath', '/usr/local/lib'])
 
-def copy_libs(target, source, env):
-    if sys.platform != 'linux2':
-        return
-
-    import shutil
-    for lib in libs:
-        srclib = '/usr/local/lib/'+lib+'.so' + ('.'+linux_boost_version if 'boost' in lib else '')
-        shutil.copy2(srclib, '.')
-
-
-copy_libs_cmd = Command(target="copy-libs",
-                     source=[],
-                     action=copy_libs)
+    def copy_libs(target, source, env):
+        if sys.platform != 'linux2':
+            return
+        for lib in libs:
+            srclib = '/usr/local/lib/'+lib+'.so' + ('.'+linux_boost_version if 'boost' in lib else '')
+            shutil.copy2(srclib, '.')
 
 
-Depends( copy_libs_cmd, protean_test )
+    copy_libs_cmd = Command(target = "copy-libs",
+                            source = [],
+                            action = copy_libs)
+
+    Depends( copy_libs_cmd, protean_test )
+

--- a/SConstruct
+++ b/SConstruct
@@ -24,7 +24,7 @@ lib_path = os.getenv('LIBPATH', '').split(os.pathsep) + ["#"]
 
 env = Environment(ENV       = {'PATH': os.getenv('PATH')},
                   CPPPATH   = cpp_path,
-                  CPPFLAGS  = ['-Wno-multichar', '-std=c++11',
+                  CPPFLAGS  = ['-Wno-deprecated-declarations', '-Wno-multichar', '-std=c++11',
                                '-O3', '-fdata-sections', '-ffunction-sections'],
                   LINKFLAGS = link_flags,
                   LIBPATH   = lib_path)


### PR DESCRIPTION
It also now passes `PATH` through to subprocesses. (The fact that `scons` suppresses this by default was causing some issues in cases where tools - `g++` in particular - were installed in `/opt` rather than `/usr/bin`.)