### PR TITLE
* Treat unicode strings properly by encoding them to UTF-8

### DIFF
--- a/bindings/cs/Protean-cs/Protean.Net.Tests/Protean.Net.Tests.csproj
+++ b/bindings/cs/Protean-cs/Protean.Net.Tests/Protean.Net.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net462;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Protean.Net.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../Protean.Net/protean.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/bindings/cs/Protean-cs/Protean.Net.Tests/TestBinaryStreams.cs
+++ b/bindings/cs/Protean-cs/Protean.Net.Tests/TestBinaryStreams.cs
@@ -18,6 +18,7 @@ namespace Protean.Test
             double argDouble = double.MaxValue;
             float argFloat = float.MaxValue;
             string argString = "test string";
+            string argUnicodeString = "öɏॳ";
             DateTime argDateTime = new DateTime(2010, 1, 2, 3, 4, 5, 6);
             TimeSpan argTime = new TimeSpan(0, 1, 2, 3, 4);
 
@@ -30,6 +31,7 @@ namespace Protean.Test
             v1.Add("Float", new Variant(argFloat));
             v1.Add("Double", new Variant(argDouble));
             v1.Add("String", new Variant(argString));
+            v1.Add("UnicodeString", new Variant(argUnicodeString));
             v1.Add("DateTime", new Variant(argDateTime));
             v1.Add("Time", new Variant(argTime));
             v1.Add("None", new Variant(Variant.EnumType.None));
@@ -41,6 +43,7 @@ namespace Protean.Test
 
             Assert.AreEqual(v2.Type, Variant.EnumType.Dictionary);
             Assert.AreEqual(v2["String"].Type, Variant.EnumType.String);
+            Assert.AreEqual(v2["UnicodeString"].Type, Variant.EnumType.String);
             Assert.AreEqual(v2["Int32"].Type, Variant.EnumType.Int32);
             Assert.AreEqual(v2["UInt32"].Type, Variant.EnumType.UInt32);
             Assert.AreEqual(v2["Int64"].Type, Variant.EnumType.Int64);
@@ -53,6 +56,7 @@ namespace Protean.Test
             Assert.AreEqual(v2["None"].Type, Variant.EnumType.None);
 
             Assert.AreEqual(v2["String"].As<string>(), argString);
+            Assert.AreEqual(v2["UnicodeString"].As<string>(), argUnicodeString);
             Assert.AreEqual(v2["Int32"].As<Int32>(), argInt32);
             Assert.AreEqual(v2["UInt32"].As<UInt32>(), argUInt32);
             Assert.AreEqual(v2["Int64"].As<Int64>(), argInt64);

--- a/bindings/cs/Protean-cs/Protean.Net/BinaryReader.cs
+++ b/bindings/cs/Protean-cs/Protean.Net/BinaryReader.cs
@@ -304,15 +304,8 @@ namespace Protean {
 
 			if (length > 0)
 			{
-				byte[] bytes = ReadBytes(length, true);
-
-				unsafe
-				{
-					fixed (byte* ptr = bytes)
-					{
-					    return Encoding.UTF8.GetString(ptr, length);
-					}
-				}
+				var bytes = ReadBytes(length, true);
+			    return Encoding.UTF8.GetString(bytes);
 			}
 			else
 			{

--- a/bindings/cs/Protean-cs/Protean.Net/BinaryWriter.cs
+++ b/bindings/cs/Protean-cs/Protean.Net/BinaryWriter.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 
 namespace Protean
 {
@@ -107,20 +108,9 @@ namespace Protean
 
         public void WriteString(string arg)
         {
-            int length = arg.Length;
-            byte[] bytes = new byte[length];
+            var bytes = Encoding.UTF8.GetBytes(arg);
 
-            for (int i = 0; i < length; ++i)
-            {
-                if (arg[i] > byte.MaxValue)
-                {
-                    throw new NotSupportedException("Unicode characters that need more than one byte are not supported");
-                }
-
-                bytes[i] = (byte)arg[i];
-            }
-
-            WriteInt(length);
+            WriteInt(bytes.Length);
             WriteBytes(bytes, true);
         }
 

--- a/bindings/cs/Protean-cs/Protean.Net/Protean.Net.csproj
+++ b/bindings/cs/Protean-cs/Protean.Net/Protean.Net.csproj
@@ -1,10 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyTitle>Protean.Net</AssemblyTitle>
-    <VersionPrefix>2.3.2</VersionPrefix>
     <Authors>Winton</Authors>
-    <TargetFrameworks>netstandard1.3;net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Protean.Net</AssemblyName>
     <AssemblyOriginatorKeyFile>protean.snk</AssemblyOriginatorKeyFile>
@@ -16,6 +15,8 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <Version>2.5.1</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,12 +29,5 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);DISABLE_XMLVALIDATION;DISABLE_DATATABLE;DISABLE_SERIALIZATION</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* No need to target .NET framework for the library - netstandard2.0 covers everything